### PR TITLE
New configurations for agent pools and docker images

### DIFF
--- a/validator/src/index.ts
+++ b/validator/src/index.ts
@@ -56,8 +56,12 @@ program
     );
     let problemConfiguration = await problemCode.getProblemConfiguration();
     console.table([
+      [ "inputType", problemConfiguration.inputType ],
+      [ "desktopEnabled", problemConfiguration.desktopEnabled ],
       [ "ideEnabled", problemConfiguration.ideEnabled ],
-      [ "inputType", problemConfiguration.inputType ]
+      [ "vsliteEnabled", problemConfiguration.vsliteEnabled ],
+      [ "agentPool", problemConfiguration.agentPool ],
+      [ "agentImage", problemConfiguration.agentImage ]
     ])
 
     const worskpaceFolder = path.join(process.cwd(), "..", "workspace");
@@ -79,9 +83,11 @@ program
         for (const validationStep of validationSteps)
         {
             const workingDirectory = path.join(worskpaceFolder, validationStep.workingDirectory ?? '');
-            console.log(`name            : ${validationStep.name}`);
-            console.log(`workingDirectory: ${workingDirectory}`);
-            console.log(`cmd             : ${validationStep.cmd}`);
+            console.log(`/=======================================================`);
+            console.log(`| name            : ${validationStep.name}`);
+            console.log(`| workingDirectory: ${workingDirectory}`);
+            console.log(`| cmd             : ${validationStep.cmd}`);
+            console.log(`\\=======================================================`);
 
             //
             // Run the command
@@ -101,6 +107,8 @@ program
                 const resultPath = path.join(workingDirectory, validationStep.results);
                 buildTestResultFileNames.push(resultPath)
             }
+
+            console.log(``);
 
         }
     } catch (e) {

--- a/validator/src/interfaces.ts
+++ b/validator/src/interfaces.ts
@@ -51,6 +51,8 @@ export class ProblemConfiguration {
   ideEnabled: boolean = false
   desktopEnabled = false;
   vsliteEnabled = false;
+  agentPool = '';
+  agentImage = '';
 }
 
 /**

--- a/validator/src/validator.ts
+++ b/validator/src/validator.ts
@@ -111,9 +111,17 @@ export class Validator implements DevMatchValidator {
     const rawConfig = CHALLENGE_YAML_STRING.configuration;
 
     let config = new ProblemConfiguration();
-    config.ideEnabled =
-      rawConfig.find((config) => config.ideEnabled !== undefined)?.ideEnabled ||
-      false;
+
+    const getConfig = (configName, defaultValue) => {
+        const configObject = rawConfig.find(c => Object.hasOwn(c, configName));
+        return configObject ? (configObject[configName] || defaultValue) : defaultValue;
+    }
+
+    config.ideEnabled =     getConfig('ideEnabled', false);
+    config.vsliteEnabled =  getConfig('vsliteEnabled', false);
+    config.desktopEnabled = getConfig('desktopEnabled', false);
+    config.agentPool = getConfig('agentPool', 'default');
+    config.agentImage = getConfig('agentImage', 'default');
 
     // The Yaml contains strings, turn that into types:
     const rawInputType = rawConfig.find(


### PR DESCRIPTION
* New agent pool and agent image configurations. DevMatch now supports creating environments in more than one host. These hosts are known as agent pools.
* Within each agent pool, you can have more than one docker image that gets instantiated when a user requests a new environment.
* These options are now optional. 
* Small tweaks to the logging to better distinguish the output of each command.